### PR TITLE
Remove processes that have zero norm

### DIFF
--- a/fitting/PbbJet/makeCardsHbb.py
+++ b/fitting/PbbJet/makeCardsHbb.py
@@ -41,6 +41,7 @@ def main(options,args):
     nSig = len(sigs)
     numberOfMassBins = 23    
     numberOfPtBins = 6
+    procsToRemove = []
 
     histoDict = {}
     histoDictLoose = {}
@@ -75,7 +76,7 @@ def main(options,args):
     #dctpl = open("datacardZbb.tpl")
     #dctpl = open("datacardZonly.tpl")
 
-    linel = [];
+    linel = []
     for line in dctpl: 
         print line.strip().split()
         linel.append(line.strip())
@@ -107,7 +108,9 @@ def main(options,args):
                 else:
                     jesErrs['%s_%s'%(proc,box)] =  1.0
                     jerErrs['%s_%s'%(proc,box)] =  1.0
-
+                    puErrs['%s_%s'%(proc,box)] =  1.0
+                    print "to remove: proc, cat, box, rate =", proc, "cat%i"%i, box, rate
+                    procsToRemove.append((proc, "cat%i"%i, box))
                 if i == 2:
                     scaleptErrs['%s_%s'%(proc,box)] =  0.05
                 elif i == 3:
@@ -143,8 +146,12 @@ def main(options,args):
                             
                         error = array.array('d',[0.0])
                         rate = histo.IntegralAndError(1,histo.GetNbinsX(),i,i,error)                 
-                        #mcstatErrs['%s_%s'%(proc,box),i,j] = 1.0+histo.GetBinError(j,i)/histo.Integral()
-                        mcstatErrs['%s_%s'%(proc,box),i,j] = 1.0+(error[0]/rate)
+                        if rate>0:
+                            mcstatErrs['%s_%s'%(proc,box),i,j] = 1.0+(error[0]/rate)
+                        else:
+                            mcstatErrs['%s_%s'%(proc,box),i,j] = 1.0
+                            if (proc, "cat%i"%i, box) not in procsToRemove:
+                                procsToRemove.append((proc, "cat%i"%i, box))
                     else:
                         mcstatErrs['%s_%s'%(proc,box),i,j] = 1.0
                         
@@ -249,7 +256,7 @@ def main(options,args):
             for proc in sigs+bkgs:
                 if options.forcomb and '2017' in proc:
                     proc = proc.replace("2017","")
-                if options.noMcStatShape and proc!='qcd' and proc!='qcd2017':                        
+                if options.noMcStatShape and proc!='qcd' and proc!='qcd2017' and (proc, 'cat%i'%i, box) not in procsToRemove:
                     print 'include %s%scat%imcstat'%(proc,box,i)
                     dctmp.write(mcStatStrings['%s_%s'%(proc,box),i,1].replace('mcstat1','mcstat') + "\n")
                     mcStatGroupString += ' %s%scat%imcstat'%(proc,box,i)
@@ -286,8 +293,43 @@ def main(options,args):
 
         dctmp.write(mcStatGroupString + "\n")
         dctmp.write(qcdGroupString + "\n")
+        dctmp.close()
+    def removeProc(proc, tag, box):
+        dctmp = open(options.odir+"/card_rhalphabet_%s.txt" % tag, 'r')
+        linel = []
+        firstProcessLine = True
+        for iline, line in enumerate(dctmp):
+            l = line.strip().split()
+            linel.append(l)
+        for iline, l in enumerate(linel):
+            if l[0]=='process' and firstProcessLine: 
+                totalProcs = len(l)-1
+                #procIndex = l.index(proc)
+                procIndex = [il for il, nl in enumerate(l) if nl == proc][0] # first instance of process (pass category)
+                if linel[iline-1][procIndex]!='%s_%s'%(box,tag):
+                    procIndex = [il for il, nl in enumerate(l) if nl == proc][1] # second instance of process (fail category)
+                if linel[iline-1][procIndex]=='%s_%s'%(box,tag):
+                    print "REMOVING", proc, tag, box                    
+                else:
+                    print "NOT REMOVING; NO MATCH", proc, tag, box                    
+                l.pop(procIndex)
+                linel[iline] = l
+                linel[iline-1].pop(procIndex)
+                firstProcessLine = False
+            elif not firstProcessLine and len(l) > 1 and l[1]=='group':
+                continue
+            elif not firstProcessLine and len(l)==totalProcs+1:
+                l.pop(procIndex)
+                linel[iline] = l
+            elif not firstProcessLine and len(l)==totalProcs+2:
+                l.pop(procIndex+1)     
+                linel[iline]= l
+        dctmp.close()
+        dctmp_w = open(options.odir+"/card_rhalphabet_%s.txt" % tag, 'w')
+        for l in linel: dctmp_w.write(' '.join(l)+'\n')
 
-
+    for proc, tag, box in procsToRemove: 
+        removeProc(proc, tag, box)
 ###############################################################
 
 

--- a/fitting/rhalphabet_builder.py
+++ b/fitting/rhalphabet_builder.py
@@ -173,8 +173,10 @@ class RhalphabetBuilder():
             rescaled_int_up = datahist['%s_%s' % (proc, cat)].sumEntries() * (1. + (ipt-iptlo) * (total_unc-1.) / (ipthi-iptlo)) * (all_int / all_int_rescale_Up)
             rescaled_int_down = datahist['%s_%s' % (proc, cat)].sumEntries() / (1. + (ipt-iptlo) * (total_unc-1.) / (ipthi-iptlo)) * (all_int / all_int_rescale_Down)
 
-            hist_up.Scale(rescaled_int_up/hist_up.Integral())
-            hist_down.Scale(rescaled_int_down/hist_down.Integral())
+            if hist_up.Integral()>0:
+                hist_up.Scale(rescaled_int_up/hist_up.Integral())
+            if hist_down.Integral()>0:
+                hist_down.Scale(rescaled_int_down/hist_down.Integral())
 
             # validation
             self._outfile_validation.cd()


### PR DESCRIPTION
@kakwok Try this out.

Remove processes from data card that have zero norm. Tested using files from `/uscms/home/kkwok/work/Hbb/CMSSW_8_1_0/src/ZPrimePlusJet/fitting/PbbJet/QG` and combine 81X:
```
cd CMSSW_8_1_0/src/ZPrimePlusJet/
cmsenv
source setup.sh
cd fitting/PbbJet/
python buildRhalphabetHbb.py -i QG/QGquark/hist_1DZbb_pt_scalesmear.root -o QG/QGquark/mcOnly/ --remove-unmatched --prefit --addHptShape --pseudo
python makeCardsHbb.py -i QG/QGquark/hist_1DZbb_pt_scalesmear.root -o QG/QGquark/mcOnly/ --remove-unmatched --no-mcstat-shape
cd QG/QGquark/mcOnly/
text2workspace.py -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel -m 125  --PO verbose --PO 'map=.*/hqq125:r[1,0,20]' --PO 'map=.*/vbfhqq125:r_vbf[1,0,20]' card_rhalphabet.txt -o card_rhalphabet_floatVBF.root
combine -M MultiDimFit -d card_rhalphabet_floatVBF.root --setRobustFitTolerance 0.001  --setRobustFitStrategy 2 --setParameterRanges r=-10,10:r_vbf=-20,20 --algo singles   -t -1 --toysFreq --setParameters r=1,r_vbf=1 --robustFit 1  --setRobustFitAlgo Minuit2,Migrad --freezeParameters tqqeffSF,tqqnormSF
```

Result (note `r` here just scales ggF and `r_vbf` scales VBF):
```
 <<< Combine >>> 
>>> including systematics
   Options for Robust Minimizer :: 
        Tolerance  0.001
        Strategy   2
        Type,Algo  Minuit2,Migrad
>>> method used is MultiDimFit
>>> random number generator seed is 123456
ModelConfig 'ModelConfig' defines more than one parameter of interest. This is not supported in some statistical methods.
Set Range of Parameter r To : (-10,10)
Set Range of Parameter r_vbf To : (-20,20)
Set Default Value of Parameter r To : 1
Set Default Value of Parameter r_vbf To : 1
Computing results starting from expected outcome (a-priori)
Constraints of type SimpleGaussianConstraint: 95

 --- MultiDimFit ---
best fit parameter values and profile-likelihood uncertainties: 
       r :    +1.000   -7.220/+7.916 (68%)
   r_vbf :    +1.000   -13.453/+13.818 (68%)
Done in 1.81 min (cpu), 1.81 min (real)
```