### PR TITLE
Use exp(bernstein poly) as alternative function with option for RooMultiPdf

### DIFF
--- a/fitting/PbbJet/buildRhalphabetHbb.py
+++ b/fitting/PbbJet/buildRhalphabetHbb.py
@@ -80,7 +80,7 @@ def main(options, args):
     # Build the workspacees
     #dazsleRhalphabetBuilder(hpass, hfail, f, odir, options.NR, options.NP)
 
-    rhalphabuilder = RhalphabetBuilder(pass_hists, fail_hists, f, options.odir, nr=options.NR, np=options.NP, mass_nbins=MASS_BINS, mass_lo=MASS_LO, mass_hi=MASS_HI, blind_lo=BLIND_LO, blind_hi=BLIND_HI, rho_lo=RHO_LO, rho_hi=RHO_HI, blind=options.blind, mass_fit=options.massfit, freeze_poly=options.freeze, remove_unmatched=options.removeUnmatched, input_file_loose=fLoose,suffix=options.suffix,sf_dict=sf,mass_hist_lo=MASS_HIST_LO,mass_hist_hi=MASS_HIST_HI)
+    rhalphabuilder = RhalphabetBuilder(pass_hists, fail_hists, f, options.odir, nr=options.NR, np=options.NP, mass_nbins=MASS_BINS, mass_lo=MASS_LO, mass_hi=MASS_HI, blind_lo=BLIND_LO, blind_hi=BLIND_HI, rho_lo=RHO_LO, rho_hi=RHO_HI, blind=options.blind, mass_fit=options.massfit, freeze_poly=options.freeze, remove_unmatched=options.removeUnmatched, input_file_loose=fLoose,suffix=options.suffix,sf_dict=sf,mass_hist_lo=MASS_HIST_LO,mass_hist_hi=MASS_HIST_HI,exp=options.exp)
     rhalphabuilder.run()
     if options.addHptShape:
         rhalphabuilder.addHptShape()	
@@ -106,6 +106,8 @@ if __name__ == '__main__':
                       metavar='useQCD')
     parser.add_option('--massfit', action='store_true', dest='massfit', default=False, help='mass fit or rho',
                       metavar='massfit')
+    parser.add_option('--exp', action='store_true', dest='exp', default=False, help='use exp(bernstein poly) transfer function',
+                      metavar='exp')
     parser.add_option('--freeze', action='store_true', dest='freeze', default=False, help='freeze pol values',
                       metavar='freeze')
     parser.add_option('--scale', dest='scale', default=1, type='float',

--- a/fitting/PbbJet/buildRhalphabetHbb.py
+++ b/fitting/PbbJet/buildRhalphabetHbb.py
@@ -80,7 +80,7 @@ def main(options, args):
     # Build the workspacees
     #dazsleRhalphabetBuilder(hpass, hfail, f, odir, options.NR, options.NP)
 
-    rhalphabuilder = RhalphabetBuilder(pass_hists, fail_hists, f, options.odir, nr=options.NR, np=options.NP, mass_nbins=MASS_BINS, mass_lo=MASS_LO, mass_hi=MASS_HI, blind_lo=BLIND_LO, blind_hi=BLIND_HI, rho_lo=RHO_LO, rho_hi=RHO_HI, blind=options.blind, mass_fit=options.massfit, freeze_poly=options.freeze, remove_unmatched=options.removeUnmatched, input_file_loose=fLoose,suffix=options.suffix,sf_dict=sf,mass_hist_lo=MASS_HIST_LO,mass_hist_hi=MASS_HIST_HI,exp=options.exp)
+    rhalphabuilder = RhalphabetBuilder(pass_hists, fail_hists, f, options.odir, nr=options.NR, np=options.NP, mass_nbins=MASS_BINS, mass_lo=MASS_LO, mass_hi=MASS_HI, blind_lo=BLIND_LO, blind_hi=BLIND_HI, rho_lo=RHO_LO, rho_hi=RHO_HI, blind=options.blind, mass_fit=options.massfit, freeze_poly=options.freeze, remove_unmatched=options.removeUnmatched, input_file_loose=fLoose,suffix=options.suffix,sf_dict=sf,mass_hist_lo=MASS_HIST_LO,mass_hist_hi=MASS_HIST_HI,exp=options.exp,multi=options.multi)
     rhalphabuilder.run()
     if options.addHptShape:
         rhalphabuilder.addHptShape()	
@@ -108,6 +108,8 @@ if __name__ == '__main__':
                       metavar='massfit')
     parser.add_option('--exp', action='store_true', dest='exp', default=False, help='use exp(bernstein poly) transfer function',
                       metavar='exp')
+    parser.add_option('--multi', action='store_true', dest='multi', default=False, help='define RooMultiPdf',
+                      metavar='multi')
     parser.add_option('--freeze', action='store_true', dest='freeze', default=False, help='freeze pol values',
                       metavar='freeze')
     parser.add_option('--scale', dest='scale', default=1, type='float',

--- a/fitting/PbbJet/makeCardsHbb.py
+++ b/fitting/PbbJet/makeCardsHbb.py
@@ -276,6 +276,13 @@ def main(options,args):
         for l in linel:
             if 'shapes qcd' in l:
                 newline = l+options.suffix
+                if options.multi:
+                    newline = newline.replace('qcd','qcd_multi')
+            elif 'qcd' in l:
+                if options.multi:
+                    newline = l.replace('qcd','qcd_multi')
+                else:
+                    newline = l
             elif 'lumi' in l:
                 newline = lumiString
             elif 'JES' in l:
@@ -424,6 +431,9 @@ if __name__ == '__main__':
     parser.add_option('--remove-unmatched', action='store_true', dest='removeUnmatched', default =False,help='remove unmatched', metavar='removeUnmatched')
     parser.add_option('--no-mcstat-shape', action='store_true', dest='noMcStatShape', default =False,help='change mcstat uncertainties to lnN', metavar='noMcStatShape')
     parser.add_option('--suffix', dest='suffix', default='', help='suffix for conflict variables',metavar='suffix')
+    parser.add_option('--multi', action='store_true', dest='multi', default=False, help='define RooMultiPdf',
+                      metavar='multi')
+
 
     (options, args) = parser.parse_args()
 

--- a/fitting/rhalphabet_builder.py
+++ b/fitting/rhalphabet_builder.py
@@ -28,7 +28,7 @@ from hist import *
 class RhalphabetBuilder():
     def __init__(self, pass_hists, fail_hists, input_file, out_dir, nr=2, np=1, mass_nbins=23, mass_lo=40, mass_hi=201,
                  blind_lo=110, blind_hi=131, rho_lo=-6, rho_hi=-2.1, blind=False, mass_fit=False, freeze_poly=False,
-                 remove_unmatched=False, input_file_loose=None,suffix=None,sf_dict={},mass_hist_lo=40,mass_hist_hi=201):
+                 remove_unmatched=False, input_file_loose=None,suffix=None,sf_dict={},mass_hist_lo=40,mass_hist_hi=201,exp=False):
         self._pass_hists = pass_hists
         self._fail_hists = fail_hists
         self._mass_fit = mass_fit
@@ -67,7 +67,7 @@ class RhalphabetBuilder():
         # polynomial order for fit
         self._poly_degree_rho = nr  # 1 = linear ; 2 is quadratic
         self._poly_degree_pt = np  # 1 = linear ; 2 is quadratic
-
+        self._exp = exp
         self._nptbins = pass_hists["data_obs"].GetYaxis().GetNbins()
         self._pt_lo = pass_hists["data_obs"].GetYaxis().GetBinLowEdge(1)
         self._pt_hi = pass_hists["data_obs"].GetYaxis().GetBinUpEdge(self._nptbins)
@@ -505,8 +505,11 @@ class RhalphabetBuilder():
                 print ("Pt/Rho poly")
                 #roopolyarray = self.buildRooPolyRhoArray(self._lPt.getVal(), self._lRho.getVal(), lUnity, lZero,
                 #                                         polynomial_variables)
-                #roopolyarray = self.buildRooPolyRhoArrayBernstein(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
-                roopolyarray = self.buildRooPolyRhoArrayBernsteinExp(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
+                if self._exp:
+                    roopolyarray = self.buildRooPolyRhoArrayBernsteinExp(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
+                else:
+                    roopolyarray = self.buildRooPolyRhoArrayBernstein(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
+
             print "RooPolyArray:"
             roopolyarray.Print()
             fail_bin_content = 0

--- a/fitting/rhalphabet_builder.py
+++ b/fitting/rhalphabet_builder.py
@@ -505,7 +505,8 @@ class RhalphabetBuilder():
                 print ("Pt/Rho poly")
                 #roopolyarray = self.buildRooPolyRhoArray(self._lPt.getVal(), self._lRho.getVal(), lUnity, lZero,
                 #                                         polynomial_variables)
-                roopolyarray = self.buildRooPolyRhoArrayBernstein(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
+                #roopolyarray = self.buildRooPolyRhoArrayBernstein(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
+                roopolyarray = self.buildRooPolyRhoArrayBernsteinExp(self._lPt.getVal(),self._lRho.getVal(),lUnity,lZero,polynomial_variables)
             print "RooPolyArray:"
             roopolyarray.Print()
             fail_bin_content = 0
@@ -714,6 +715,54 @@ class RhalphabetBuilder():
         lRhoArray.add(lRho_rescaled)
         print "lRhoArray: ", lRhoArray.Print()
         lRhoPol = r.RooFormulaVar(lLabel, lLabel, rhoPolyString, lRhoArray)
+        self._all_vars.extend([lPt_rescaled, lRho_rescaled, lRhoPol])
+        return lRhoPol
+
+
+    def buildRooPolyRhoArrayBernsteinExp(self, iPt, iRho, iQCD, iZero, iVars):
+
+        print "---- [buildRooPolyArrayBernsteinExp]"
+
+        lPt = r.RooConstVar("Var_Pt_" + str(iPt) + "_" + str(iRho), "Var_Pt_" + str(iPt) + "_" + str(iRho), (iPt))
+        lPt_rescaled = r.RooConstVar("Var_Pt_rescaled_" + str(iPt) + "_" + str(iRho),
+                                     "Var_Pt_rescaled_" + str(iPt) + "_" + str(iRho),
+                                     ((iPt - self._pt_lo) / (self._pt_hi - self._pt_lo)))
+        lRho = r.RooConstVar("Var_Rho_" + str(iPt) + "_" + str(iRho), "Var_Rho_" + str(iPt) + "_" + str(iRho), (iRho))
+        lRho_rescaled = r.RooConstVar("Var_Rho_rescaled_" + str(round(iPt, 2)) + "_" + str(round(iRho, 3)),
+                                      "Var_Rho_rescaled_" + str(round(iPt, 2)) + "_" + str(round(iRho, 3)),
+                                      ((iRho - self._rho_lo) / (self._rho_hi - self._rho_lo)))
+
+        ptPolyString = self.generate_bernstein_string(self._poly_degree_pt)
+        rhoPolyString = self.generate_bernstein_string(self._poly_degree_rho)
+
+        lRhoArray = r.RooArgList()
+        lNCount = 0
+        for pRVar in range(0, self._poly_degree_rho + 1):
+            lTmpArray = r.RooArgList()
+            for pVar in range(0, self._poly_degree_pt + 1):
+                #if lNCount == 0:
+                #    lTmpArray.add(iQCD)  # for the very first constant (e.g. p0r0), just set that to 1
+                #else:
+                print "lNCount = " + str(lNCount)
+                lTmpArray.add(iVars[lNCount])
+                print "iVars[lNCount]: ", iVars[lNCount]
+                print "iVars[lNCount]"
+                iVars[lNCount].Print()
+                lNCount = lNCount + 1
+            pLabel = "Var_Pol_Bin_" + str(round(iPt, 2)) + "_" + str(round(iRho, 3)) + "_" + str(pRVar)
+            lTmpArray.add(lPt_rescaled)
+            print "lTmpArray: ", lTmpArray.Print()
+            pPol = r.RooFormulaVar(pLabel, pLabel, ptPolyString, lTmpArray)
+            print "pPol:"
+            print pPol.Print("V")
+            lRhoArray.add(pPol)
+            self._all_vars.append(pPol)
+
+        lLabel = "Var_RhoPol_Bin_" + str(round(iPt, 2)) + "_" + str(round(iRho, 3))
+        lRhoArray.add(lRho_rescaled)
+        print "lRhoArray: ", lRhoArray.Print()
+        lRhoPol = r.RooFormulaVar(lLabel, lLabel, 'exp('+rhoPolyString+')', lRhoArray)
+        print('exp('+rhoPolyString+')')
         self._all_vars.extend([lPt_rescaled, lRho_rescaled, lRhoPol])
         return lRhoPol
 


### PR DESCRIPTION
- Use exp(bernstein poly) and add option for RooMultiPdf.
- Add option for RooMultiPdf
- Currently assumes exponential and polynomial have same number of parameters (2, 2 is hardcoded at the moment) 
- Not yet validated (still has a bug with RooMultiPdf setup)

Testing with poly(2,2):
```bash
#!/bin/bash
pushd ../../
cmsenv
source setup.sh
popd
mkdir -p ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4
python buildRhalphabetHbb.py -i ddb_Jun6_v2/ddb_M2_full/data/hist_1DZbb_pt_scalesmear.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4/ --nr 2 --np 2 --remove-unmatched --prefit --addHptShape  --suffix 2017 --blind  --year 2017 
python makeCardsHbb.py       -i ddb_Jun6_v2/ddb_M2_full/data/hist_1DZbb_pt_scalesmear.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4/ --remove-unmatched --no-mcstat-shape  --suffix 2017 --blind  --year 2017 
python writeMuonCRDatacard.py  -i ddb_Jun6_v2/ddb_M2_full/muonCR/hist_1DZbb_muonCR.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4/  --year 2017 
pushd ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4/ 
combineCards.py  cat1_2017=card_rhalphabet_cat1.txt  cat2_2017=card_rhalphabet_cat2.txt  cat3_2017=card_rhalphabet_cat3.txt  cat4_2017=card_rhalphabet_cat4.txt  cat5_2017=card_rhalphabet_cat5.txt  cat6_2017=card_rhalphabet_cat6.txt  muonCR_2017=datacard_muonCR.txt  > card_rhalphabet_all_2017.txt
text2workspace.py -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel -m 125  --PO verbose --PO 'map=.*/*hqq125:r[1,0,20]' --PO 'map=.*/zqq:r_z[1,0,20]' card_rhalphabet_all_2017.txt  -o card_rhalphabet_all_2017_floatZ.root
combine -M MultiDimFit -d card_rhalphabet_all_2017_floatZ.root --redefineSignalPOIs r,r_z,tqqnormSF_2017,tqqeffSF_2017  --setRobustFitTolerance  0.001 --setRobustFitStrategy 2 --algo singles --robustFit 1  --setRobustFitAlgo Minuit2,Migrad --saveWorkspace --setParameterRanges r=-10,10:r_z=-5,5 --setParameters r=1,r_z=1 --freezeParameters  r
popd
```

Testing with exp(2,2):
```bash
#!/bin/bash
pushd ../../
cmsenv
source setup.sh
popd
mkdir -p ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_exp
python buildRhalphabetHbb.py -i ddb_Jun6_v2/ddb_M2_full/data/hist_1DZbb_pt_scalesmear.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_exp/ --nr 2 --np 2 --remove-unmatched --prefit --addHptShape  --suffix 2017 --blind  --year 2017 --exp
python makeCardsHbb.py       -i ddb_Jun6_v2/ddb_M2_full/data/hist_1DZbb_pt_scalesmear.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_exp/ --remove-unmatched --no-mcstat-shape  --suffix 2017 --blind  --year 2017 
python writeMuonCRDatacard.py  -i ddb_Jun6_v2/ddb_M2_full/muonCR/hist_1DZbb_muonCR.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_exp/  --year 2017 
pushd ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_exp/ 
combineCards.py  cat1_2017=card_rhalphabet_cat1.txt  cat2_2017=card_rhalphabet_cat2.txt  cat3_2017=card_rhalphabet_cat3.txt  cat4_2017=card_rhalphabet_cat4.txt  cat5_2017=card_rhalphabet_cat5.txt  cat6_2017=card_rhalphabet_cat6.txt  muonCR_2017=datacard_muonCR.txt  > card_rhalphabet_all_2017.txt
text2workspace.py -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel -m 125  --PO verbose --PO 'map=.*/*hqq125:r[1,0,20]' --PO 'map=.*/zqq:r_z[1,0,20]' card_rhalphabet_all_2017.txt  -o card_rhalphabet_all_2017_floatZ.root
combine -M MultiDimFit -d card_rhalphabet_all_2017_floatZ.root --redefineSignalPOIs r,r_z,tqqnormSF_2017,tqqeffSF_2017  --setRobustFitTolerance  0.001 --setRobustFitStrategy 2 --algo singles --robustFit 1  --setRobustFitAlgo Minuit2,Migrad --saveWorkspace --setParameterRanges r=-10,10:r_z=-5,5 --setParameters r=1,r_z=1 --freezeParameters  r
popd
```

Testing with RooMultiPdf:
```
pushd ../../
cmsenv
source setup.sh
popd
mkdir -p ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_multi
python buildRhalphabetHbb.py -i ddb_Jun6_v2/ddb_M2_full/data/hist_1DZbb_pt_scalesmear.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_multi/ --nr 2 --np 2 --remove-unmatched --prefit --addHptShape  --suffix 2017 --blind  --year 2017 --multi
python makeCardsHbb.py       -i ddb_Jun6_v2/ddb_M2_full/data/hist_1DZbb_pt_scalesmear.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_multi/ --remove-unmatched --no-mcstat-shape  --suffix 2017 --blind  --year 2017 --multi
python writeMuonCRDatacard.py  -i ddb_Jun6_v2/ddb_M2_full/muonCR/hist_1DZbb_muonCR.root -o ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_multi/  --year 2017 
pushd ddb_Jun6_v2/ddb_M2_full/TF22_blind_muonCR_suffix_SFJun4_multi/ 
combineCards.py  cat1_2017=card_rhalphabet_cat1.txt  cat2_2017=card_rhalphabet_cat2.txt  cat3_2017=card_rhalphabet_cat3.txt  cat4_2017=card_rhalphabet_cat4.txt  cat5_2017=card_rhalphabet_cat5.txt  cat6_2017=card_rhalphabet_cat6.txt  muonCR_2017=datacard_muonCR.txt  > card_rhalphabet_all_2017.txt
text2workspace.py -P HiggsAnalysis.CombinedLimit.PhysicsModel:multiSignalModel -m 125  --PO verbose --PO 'map=.*/*hqq125:r[1,0,20]' --PO 'map=.*/zqq:r_z[1,0,20]' card_rhalphabet_all_2017.txt  -o card_rhalphabet_all_2017_floatZ.root
combine -M MultiDimFit -d card_rhalphabet_all_2017_floatZ.root --redefineSignalPOIs r,r_z,tqqnormSF_2017,tqqeffSF_2017  --setRobustFitTolerance  0.001 --setRobustFitStrategy 2 --algo singles --robustFit 1  --setRobustFitAlgo Minuit2,Migrad --saveWorkspace --setParameterRanges r=-10,10:r_z=-5,5 --setParameters r=1,r_z=1,pdf_index=0 --freezeParameters  r,pdf_index,expp0r0_2017,expp0r1_2017,expp0r2_2017,expp1r0_2017,expp1r1_2017,expp1r2_2017,expp2r0_2017,expp2r1_2017,expp2r2_2017
combine -M MultiDimFit -d card_rhalphabet_all_2017_floatZ.root --redefineSignalPOIs r,r_z,tqqnormSF_2017,tqqeffSF_2017  --setRobustFitTolerance  0.001 --setRobustFitStrategy 2 --algo singles --robustFit 1  --setRobustFitAlgo Minuit2,Migrad --saveWorkspace --setParameterRanges r=-10,10:r_z=-5,5 --setParameters r=1,r_z=1,pdf_index=1 --freezeParameters  r,pdf_index,p0r0_2017,p0r1_2017,p0r2_2017,p1r0_2017,p1r1_2017,p1r2_2017,p2r0_2017,p2r1_2017,p2r2_2017
popd
```